### PR TITLE
Add nsswitch config

### DIFF
--- a/latest/overlay/etc/nsswitch.conf
+++ b/latest/overlay/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns

--- a/v3.10/overlay/etc/nsswitch.conf
+++ b/v3.10/overlay/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns

--- a/v3.9/overlay/etc/nsswitch.conf
+++ b/v3.9/overlay/etc/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns


### PR DESCRIPTION
Tools written in Go rely on the existance of a nsswitch configuration,
      but this is not provided Alpine, that's why we are adding it
      manually now.