### PR TITLE
Replace wait-for-it with static binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2019-10-14
+
+* Fixed
+  * Downloaded tools got to be executable
+* Changed
+  * Replace wait-for-it with a static binary
+
 ## 2019-10-08
 
 * Changed

--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -1,18 +1,23 @@
 FROM alpine:edge as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-amd64-slim
 ENV GOMPLATE_CHECKSUM=ba6cf854da46f9d9a50d26ec7d4a8a8b24f65ecce54a8a93d23eb0b6e138d8eb
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM alpine:edge
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -1,18 +1,23 @@
 FROM arm32v7/alpine:edge as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm-slim
 ENV GOMPLATE_CHECKSUM=fb9bf19fb8e42aac690f724a3252bd5fe62322d620a8a1b1cb4308f6b684381c
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm32v7/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm32v7/alpine:edge
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -1,18 +1,23 @@
 FROM arm64v8/alpine:edge as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm64-slim
 ENV GOMPLATE_CHECKSUM=af5c65b19ac4cc72a4441e1cb286cfd9114a5fa5a30a8311cbba4d20f23255e0
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm64v8/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm64v8/alpine:edge
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/latest/overlay/usr/bin/wait-for-it
+++ b/latest/overlay/usr/bin/wait-for-it
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+while getopts "t:" o
+do
+	case ${o} in
+		t)
+			TIMEOUT=${OPTARG}
+			;;
+		*)
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+exec wait-for -t ${TIMEOUT:-20} -it "${@}"

--- a/v3.10/Dockerfile.amd64
+++ b/v3.10/Dockerfile.amd64
@@ -1,18 +1,23 @@
 FROM alpine:3.10 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-amd64-slim
 ENV GOMPLATE_CHECKSUM=ba6cf854da46f9d9a50d26ec7d4a8a8b24f65ecce54a8a93d23eb0b6e138d8eb
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM alpine:3.10
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.10/Dockerfile.arm32v7
+++ b/v3.10/Dockerfile.arm32v7
@@ -1,18 +1,23 @@
 FROM arm32v7/alpine:3.10 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm-slim
 ENV GOMPLATE_CHECKSUM=fb9bf19fb8e42aac690f724a3252bd5fe62322d620a8a1b1cb4308f6b684381c
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm32v7/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm32v7/alpine:3.10
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.10/Dockerfile.arm64v8
+++ b/v3.10/Dockerfile.arm64v8
@@ -1,18 +1,23 @@
 FROM arm64v8/alpine:3.10 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm64-slim
 ENV GOMPLATE_CHECKSUM=af5c65b19ac4cc72a4441e1cb286cfd9114a5fa5a30a8311cbba4d20f23255e0
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm64v8/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm64v8/alpine:3.10
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.10/overlay/usr/bin/wait-for-it
+++ b/v3.10/overlay/usr/bin/wait-for-it
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+while getopts "t:" o
+do
+	case ${o} in
+		t)
+			TIMEOUT=${OPTARG}
+			;;
+		*)
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+exec wait-for -t ${TIMEOUT:-20} -it "${@}"

--- a/v3.9/Dockerfile.amd64
+++ b/v3.9/Dockerfile.amd64
@@ -1,18 +1,23 @@
 FROM alpine:3.9 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-amd64-slim
 ENV GOMPLATE_CHECKSUM=ba6cf854da46f9d9a50d26ec7d4a8a8b24f65ecce54a8a93d23eb0b6e138d8eb
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM alpine:3.9
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.9/Dockerfile.arm32v7
+++ b/v3.9/Dockerfile.arm32v7
@@ -1,18 +1,23 @@
 FROM arm32v7/alpine:3.9 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm-slim
 ENV GOMPLATE_CHECKSUM=fb9bf19fb8e42aac690f724a3252bd5fe62322d620a8a1b1cb4308f6b684381c
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm32v7/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm32v7/alpine:3.9
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.9/Dockerfile.arm64v8
+++ b/v3.9/Dockerfile.arm64v8
@@ -1,18 +1,23 @@
 FROM arm64v8/alpine:3.9 as build
 
-ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
-ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
-
-RUN cd /tmp && \
-  wget -O wait-for-it ${WAIT_FOR_IT_DOWNLOAD} && \
-  echo "${WAIT_FOR_IT_CHECKSUM} *wait-for-it" | sha256sum -c -
-
 ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.0.0/gomplate_linux-arm64-slim
 ENV GOMPLATE_CHECKSUM=af5c65b19ac4cc72a4441e1cb286cfd9114a5fa5a30a8311cbba4d20f23255e0
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
-  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c -
+  echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
+  chmod +x gomplate
+
+FROM arm64v8/golang:1.13 as golang
+
+ENV CGO_ENABLED=0
+ENV WAIT_FOR_REPO=https://github.com/alioygur/wait-for
+ENV WAIT_FOR_COMMIT=a2569b146c861c574e62d416699b78efe66ed883
+
+RUN git clone ${WAIT_FOR_REPO} /go/wait-for && \
+  cd /go/wait-for && \
+  git checkout ${WAIT_FOR_COMMIT} && \
+  go build -v -a -installsuffix cgo -o /tmp/wait-for
 
 FROM arm64v8/alpine:3.9
 
@@ -43,5 +48,5 @@ RUN apk update && \
     git && \
   rm -rf /var/cache/apk/*
 
-COPY --from=build /tmp/wait-for-it /usr/bin/wait-for-it
 COPY --from=build /tmp/gomplate /usr/bin/gomplate
+COPY --from=golang /tmp/wait-for /usr/bin/wait-for

--- a/v3.9/overlay/usr/bin/wait-for-it
+++ b/v3.9/overlay/usr/bin/wait-for-it
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+while getopts "t:" o
+do
+	case ${o} in
+		t)
+			TIMEOUT=${OPTARG}
+			;;
+		*)
+			;;
+	esac
+done
+
+shift $((OPTIND-1))
+exec wait-for -t ${TIMEOUT:-20} -it "${@}"


### PR DESCRIPTION
Quite often we had problems with the wait-for-it shell script, that's
why I'm replacing the fragile bash script with a static compiled binary
based on Golang. This doesn't contain big magic, it contains roughly 70
lines of simple Go code compared to 180 lines of shell script.